### PR TITLE
Apply multitenant for qdrant

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/qdrant.py
+++ b/backend/open_webui/retrieval/vector/dbs/qdrant.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 import logging
 from urllib.parse import urlparse
 
@@ -56,6 +56,13 @@ class QdrantClient(VectorDBBase):
         else:
             self.client = Qclient(url=self.QDRANT_URI, api_key=self.QDRANT_API_KEY)
 
+        # Main collection types for multi-tenancy
+        self.MEMORY_COLLECTION = f"{self.collection_prefix}_memories"
+        self.KNOWLEDGE_COLLECTION = f"{self.collection_prefix}_knowledge"
+        self.FILE_COLLECTION = f"{self.collection_prefix}_files"
+        self.WEB_SEARCH_COLLECTION = f"{self.collection_prefix}_web-search"
+        self.HASH_BASED_COLLECTION = f"{self.collection_prefix}_hash-based"
+
     def _result_to_get_result(self, points) -> GetResult:
         ids = []
         documents = []
@@ -75,57 +82,222 @@ class QdrantClient(VectorDBBase):
             }
         )
 
-    def _create_collection(self, collection_name: str, dimension: int):
-        collection_name_with_prefix = f"{self.collection_prefix}_{collection_name}"
-        self.client.create_collection(
-            collection_name=collection_name_with_prefix,
-            vectors_config=models.VectorParams(
-                size=dimension,
-                distance=models.Distance.COSINE,
-                on_disk=self.QDRANT_ON_DISK,
-            ),
-        )
+    def _get_collection_and_tenant_id(self, collection_name: str) -> Tuple[str, str]:
+        """
+        Maps the traditional collection name to multi-tenant collection and tenant ID.
 
-        log.info(f"collection {collection_name_with_prefix} successfully created!")
+        Returns:
+            tuple: (collection_name, tenant_id)
+        """
+        # Check for user memory collections
+        tenant_id = collection_name
 
-    def _create_collection_if_not_exists(self, collection_name, dimension):
-        if not self.has_collection(collection_name=collection_name):
-            self._create_collection(
-                collection_name=collection_name, dimension=dimension
+        if collection_name.startswith("user-memory-"):
+            return self.MEMORY_COLLECTION, tenant_id
+
+        # Check for file collections
+        elif collection_name.startswith("file-"):
+            return self.FILE_COLLECTION, tenant_id
+
+        # Check for web search collections
+        elif collection_name.startswith("web-search-"):
+            return self.WEB_SEARCH_COLLECTION, tenant_id
+
+        # Handle hash-based collections (YouTube and web URLs)
+        elif len(collection_name) == 63 and all(
+            c in "0123456789abcdef" for c in collection_name
+        ):
+            return self.HASH_BASED_COLLECTION, tenant_id
+
+        else:
+            return self.KNOWLEDGE_COLLECTION, tenant_id
+
+    def _create_multi_tenant_collection_if_not_exists(
+        self, mt_collection_name: str, dimension: int = 384
+    ):
+        """
+        Creates a collection with multi-tenancy configuration if it doesn't exist.
+        Default dimension is set to 384 which corresponds to 'sentence-transformers/all-MiniLM-L6-v2'.
+        When creating collections dynamically (insert/upsert), the actual vector dimensions will be used.
+        """
+
+        if not self.client.collection_exists(mt_collection_name):
+            # Create collection with multi-tenancy config
+            self.client.create_collection(
+                collection_name=mt_collection_name,
+                vectors_config=models.VectorParams(
+                    size=dimension,
+                    distance=models.Distance.COSINE,
+                    on_disk=self.QDRANT_ON_DISK,
+                ),
+                hnsw_config=models.HnswConfigDiff(
+                    payload_m=16,  # Enable per-tenant indexing
+                    m=0,
+                    on_disk=self.QDRANT_ON_DISK,
+                ),
             )
 
-    def _create_points(self, items: list[VectorItem]):
+            # Create tenant ID payload index
+            self.client.create_payload_index(
+                collection_name=mt_collection_name,
+                field_name="tenant_id",
+                field_schema=models.KeywordIndexParams(
+                    type=models.KeywordIndexType.KEYWORD,
+                    is_tenant=True,
+                    on_disk=self.QDRANT_ON_DISK,
+                ),
+                wait=True,
+            )
+
+            log.info(
+                f"Multi-tenant collection {mt_collection_name} created with dimension {dimension}!"
+            )
+
+    def _create_points(self, items: list[VectorItem], tenant_id: str):
+        """
+        Create point structs from vector items with tenant ID.
+        """
         return [
             PointStruct(
                 id=item["id"],
                 vector=item["vector"],
-                payload={"text": item["text"], "metadata": item["metadata"]},
+                payload={
+                    "text": item["text"],
+                    "metadata": item["metadata"],
+                    "tenant_id": tenant_id,
+                },
             )
             for item in items
         ]
 
     def has_collection(self, collection_name: str) -> bool:
-        return self.client.collection_exists(
-            f"{self.collection_prefix}_{collection_name}"
+        """
+        Check if a logical collection exists by checking for any points with the tenant ID.
+        """
+        if not self.client:
+            return False
+
+        # Map to multi-tenant collection and tenant ID
+        mt_collection, tenant_id = self._get_collection_and_tenant_id(collection_name)
+
+        if not self.client.collection_exists(mt_collection):
+            return False
+
+        # Create tenant filter
+        tenant_filter = models.FieldCondition(
+            key="tenant_id", match=models.MatchValue(value=tenant_id)
         )
 
-    def delete_collection(self, collection_name: str):
-        return self.client.delete_collection(
-            collection_name=f"{self.collection_prefix}_{collection_name}"
+        try:
+            # Check if any points exist with this tenant ID
+            response = self.client.query_points(
+                collection_name=mt_collection,
+                query_filter=models.Filter(must=[tenant_filter]),
+                limit=1,
+            )
+
+            return len(response.points) > 0
+        except Exception:
+            return False
+
+    def delete(
+        self,
+        collection_name: str,
+        ids: Optional[list[str]] = None,
+        filter: Optional[dict] = None,
+    ):
+        """
+        Delete vectors by ID or filter from a collection with tenant isolation.
+        """
+        if not self.client:
+            return None
+
+        # Map to multi-tenant collection and tenant ID
+        mt_collection, tenant_id = self._get_collection_and_tenant_id(collection_name)
+
+        if not self.client.collection_exists(mt_collection):
+            return None
+
+        # Create tenant filter
+        tenant_filter = models.FieldCondition(
+            key="tenant_id", match=models.MatchValue(value=tenant_id)
         )
+
+        must_conditions = [tenant_filter]
+        should_conditions = []
+
+        if ids:
+            for id_value in ids:
+                should_conditions.append(
+                    models.FieldCondition(
+                        key="metadata.id",
+                        match=models.MatchValue(value=id_value),
+                    ),
+                )
+        elif filter:
+            for key, value in filter.items():
+                must_conditions.append(
+                    models.FieldCondition(
+                        key=f"metadata.{key}",
+                        match=models.MatchValue(value=value),
+                    ),
+                )
+
+        update_result = self.client.delete(
+            collection_name=mt_collection,
+            points_selector=models.FilterSelector(
+                filter=models.Filter(must=must_conditions, should=should_conditions)
+            ),
+        )
+
+        if self.client.get_collection(mt_collection).points_count == 0:
+            self.client.delete_collection(mt_collection)
+
+        return update_result
 
     def search(
         self, collection_name: str, vectors: list[list[float | int]], limit: int
     ) -> Optional[SearchResult]:
-        # Search for the nearest neighbor items based on the vectors and return 'limit' number of results.
-        if limit is None:
-            limit = NO_LIMIT  # otherwise qdrant would set limit to 10!
+        """
+        Search for the nearest neighbor items based on the vectors with tenant isolation.
+        """
+        if not self.client:
+            return None
 
+        # Map to multi-tenant collection and tenant ID
+        mt_collection, tenant_id = self._get_collection_and_tenant_id(collection_name)
+
+        # Get the vector dimension from the query vector
+        dimension = len(vectors[0]) if vectors and len(vectors) > 0 else None
+
+        collection_dim = self.client.get_collection(
+            mt_collection
+        ).config.params.vectors.size
+        if collection_dim != dimension:
+            if collection_dim < dimension:
+                vectors = [vector[:collection_dim] for vector in vectors]
+            else:
+                vectors = [
+                    vector + [0] * (collection_dim - dimension) for vector in vectors
+                ]
+        # Create tenant filter
+        tenant_filter = models.FieldCondition(
+            key="tenant_id", match=models.MatchValue(value=tenant_id)
+        )
+
+        # Search with tenant filter
+
+        prefetch_query = models.Prefetch(
+            filter=models.Filter(must=[tenant_filter]),
+            limit=NO_LIMIT,
+        )
         query_response = self.client.query_points(
-            collection_name=f"{self.collection_prefix}_{collection_name}",
+            collection_name=mt_collection,
             query=vectors[0],
+            prefetch=prefetch_query,
             limit=limit,
         )
+
         get_result = self._result_to_get_result(query_response.points)
         return SearchResult(
             ids=get_result.ids,
@@ -136,13 +308,30 @@ class QdrantClient(VectorDBBase):
         )
 
     def query(self, collection_name: str, filter: dict, limit: Optional[int] = None):
-        # Construct the filter string for querying
-        if not self.has_collection(collection_name):
+        """
+        Query points with filters and tenant isolation.
+        """
+        if not self.client:
             return None
+
+        # Map to multi-tenant collection and tenant ID
+        mt_collection, tenant_id = self._get_collection_and_tenant_id(collection_name)
+
+        # When using OpenAI embedding models, ensure we get the correct dimension
+
+        if not self.client.collection_exists(mt_collection):
+            return None
+
         try:
             if limit is None:
-                limit = NO_LIMIT  # otherwise qdrant would set limit to 10!
+                limit = NO_LIMIT
 
+            # Create tenant filter
+            tenant_filter = models.FieldCondition(
+                key="tenant_id", match=models.MatchValue(value=tenant_id)
+            )
+
+            # Create metadata filters
             field_conditions = []
             for key, value in filter.items():
                 field_conditions.append(
@@ -151,72 +340,182 @@ class QdrantClient(VectorDBBase):
                     )
                 )
 
+            # Combine tenant filter with metadata filters
+            combined_filter = models.Filter(must=[tenant_filter, *field_conditions])
+
             points = self.client.query_points(
-                collection_name=f"{self.collection_prefix}_{collection_name}",
-                query_filter=models.Filter(should=field_conditions),
+                collection_name=mt_collection,
+                query_filter=combined_filter,
                 limit=limit,
             )
+
             return self._result_to_get_result(points.points)
         except Exception as e:
-            log.exception(f"Error querying a collection '{collection_name}': {e}")
+            log.exception(f"Error querying collection '{collection_name}': {e}")
             return None
 
     def get(self, collection_name: str) -> Optional[GetResult]:
-        # Get all the items in the collection.
-        points = self.client.query_points(
-            collection_name=f"{self.collection_prefix}_{collection_name}",
-            limit=NO_LIMIT,  # otherwise qdrant would set limit to 10!
+        """
+        Get all items in a collection with tenant isolation.
+        """
+        if not self.client:
+            return None
+
+        # Map to multi-tenant collection and tenant ID
+        mt_collection, tenant_id = self._get_collection_and_tenant_id(collection_name)
+
+        if not self.client.collection_exists(mt_collection):
+            return None
+
+        # Create tenant filter
+        tenant_filter = models.FieldCondition(
+            key="tenant_id", match=models.MatchValue(value=tenant_id)
         )
+
+        # Get all points with tenant filter
+        points = self.client.query_points(
+            collection_name=mt_collection,
+            query_filter=models.Filter(must=[tenant_filter]),
+            limit=NO_LIMIT,
+        )
+
         return self._result_to_get_result(points.points)
 
     def insert(self, collection_name: str, items: list[VectorItem]):
-        # Insert the items into the collection, if the collection does not exist, it will be created.
-        self._create_collection_if_not_exists(collection_name, len(items[0]["vector"]))
-        points = self._create_points(items)
-        self.client.upload_points(f"{self.collection_prefix}_{collection_name}", points)
+        """
+        Insert items with tenant ID.
+        """
+        if not self.client or not items:
+            return None
+
+        # Map to multi-tenant collection and tenant ID
+        mt_collection, tenant_id = self._get_collection_and_tenant_id(collection_name)
+
+        # Get dimensions from the actual vectors
+        dimension = len(items[0]["vector"]) if items else None
+
+        # Create the collection if it doesn't exist
+        if not self.client.collection_exists(mt_collection):
+            self._create_multi_tenant_collection_if_not_exists(
+                mt_collection_name=mt_collection, dimension=dimension
+            )
+        else:
+            mt_collection_info = self.client.get_collection(mt_collection)
+            if mt_collection_info.config.params.vectors.size < dimension:
+                items = [
+                    {
+                        "id": item["id"],
+                        "text": item["text"],
+                        "vector": item["vector"][
+                            : mt_collection_info.config.params.vectors.size
+                        ],
+                        "metadata": item["metadata"],
+                    }
+                    for item in items
+                ]
+            if mt_collection_info.config.params.vectors.size > dimension:
+                target_dimension = mt_collection_info.config.params.vectors.size
+                items = [
+                    {
+                        "id": item["id"],
+                        "text": item["text"],
+                        "vector": item["vector"]
+                        + [0] * (target_dimension - len(item["vector"])),
+                        "metadata": item["metadata"],
+                    }
+                    for item in items
+                ]
+
+        # Create points with tenant ID
+        points = self._create_points(items, tenant_id)
+
+        self.client.upload_points(mt_collection, points)
 
     def upsert(self, collection_name: str, items: list[VectorItem]):
-        # Update the items in the collection, if the items are not present, insert them. If the collection does not exist, it will be created.
-        self._create_collection_if_not_exists(collection_name, len(items[0]["vector"]))
-        points = self._create_points(items)
-        return self.client.upsert(f"{self.collection_prefix}_{collection_name}", points)
+        """
+        Upsert items with tenant ID.
+        """
+        if not self.client or not items:
+            return None
 
-    def delete(
-        self,
-        collection_name: str,
-        ids: Optional[list[str]] = None,
-        filter: Optional[dict] = None,
-    ):
-        # Delete the items from the collection based on the ids.
-        field_conditions = []
+        # Map to multi-tenant collection and tenant ID
+        mt_collection, tenant_id = self._get_collection_and_tenant_id(collection_name)
 
-        if ids:
-            for id_value in ids:
-                field_conditions.append(
-                    models.FieldCondition(
-                        key="metadata.id",
-                        match=models.MatchValue(value=id_value),
-                    ),
-                ),
-        elif filter:
-            for key, value in filter.items():
-                field_conditions.append(
-                    models.FieldCondition(
-                        key=f"metadata.{key}",
-                        match=models.MatchValue(value=value),
-                    ),
-                ),
+        # Get dimensions from the actual vectors
+        dimension = len(items[0]["vector"]) if items else None
 
-        return self.client.delete(
-            collection_name=f"{self.collection_prefix}_{collection_name}",
+        # Create the collection if it doesn't exist
+        if not self.client.collection_exists(mt_collection):
+            self._create_multi_tenant_collection_if_not_exists(
+                mt_collection_name=mt_collection, dimension=dimension
+            )
+        else:
+            mt_collection_info = self.client.get_collection(mt_collection)
+            if mt_collection_info.config.params.vectors.size < dimension:
+                items = [
+                    {
+                        "id": item.id,
+                        "text": item.text,
+                        "vector": item.vector[
+                            : mt_collection_info.config.params.vectors.size
+                        ],
+                        "metadata": item.metadata,
+                    }
+                    for item in items
+                ]
+            if mt_collection_info.config.params.vectors.size > dimension:
+                target_dimension = mt_collection_info.config.params.vectors.size
+                items = [
+                    {
+                        "id": item.id,
+                        "text": item.text,
+                        "vector": item.vector
+                        + [0] * (target_dimension - len(item.vector)),
+                        "metadata": item.metadata,
+                    }
+                    for item in items
+                ]
+        # Create points with tenant ID
+        points = self._create_points(items, tenant_id)
+
+        return self.client.upsert(mt_collection, points)
+
+    def reset(self):
+        """
+        Reset the database by deleting all collections.
+        """
+        if not self.client:
+            return None
+
+        collection_names = self.client.get_collections().collections
+        for collection_name in collection_names:
+            if collection_name.name.startswith(self.collection_prefix):
+                self.client.delete_collection(collection_name=collection_name.name)
+
+    def delete_collection(self, collection_name: str):
+        """
+        Delete a collection.
+        """
+        if not self.client:
+            return None
+
+        # Map to multi-tenant collection and tenant ID
+        mt_collection, tenant_id = self._get_collection_and_tenant_id(collection_name)
+
+        tenant_filter = models.FieldCondition(
+            key="tenant_id", match=models.MatchValue(value=tenant_id)
+        )
+
+        field_conditions = [tenant_filter]
+
+        update_result = self.client.delete(
+            collection_name=mt_collection,
             points_selector=models.FilterSelector(
                 filter=models.Filter(must=field_conditions)
             ),
         )
 
-    def reset(self):
-        # Resets the database. This will delete all collections and item entries.
-        collection_names = self.client.get_collections().collections
-        for collection_name in collection_names:
-            if collection_name.name.startswith(self.collection_prefix):
-                self.client.delete_collection(collection_name=collection_name.name)
+        if self.client.get_collection(mt_collection).points_count == 0:
+            self.client.delete_collection(mt_collection)
+
+        return update_result


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** This pull request migrates Open WebUI to Qdrant's multi-tenancy feature to address excessive RAM usage and performance issues caused by the previous model of one collection per entity. It consolidates collections by entity type (Memories, Files, Knowledge, Web Search, YouTube) and uses tenant IDs for data partitioning.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following: (Suggested: `refactor`)
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Discussions
- https://github.com/open-webui/open-webui/discussions/10008

### Description

- Background: In the discussion above, we were using a separate Qdrant collection for each entity (memory, knowledge base, file), which led to thousands of collections. This approach is an anti-pattern according to Qdrant documentation and causes excessive RAM usage.

- Solution: Qdrant recommends using multi-tenancy with payload-based partitioning for efficient resource usage when dealing with a large number of logical collections (https://qdrant.tech/documentation/guides/multiple-partitions/). This change migrates the Qdrant database to utilize its multi-tenancy feature. Collections are now consolidated by entity type (Memories, Files, Knowledge, Web Search, YouTube), and data within these collections is partitioned using a `tenant_id` field in payloads.

### Changed

- Updated the existing `QdrantClient` class to use Qdrant's multi-tenancy feature while maintaining the same interface to avoid breaking changes in the application.
- Consolidated numerous individual Qdrant collections into five main entity-specific collections: `Memories Collection`, `Files Collection`, `Knowledge Collection`, `Web Search Collection`, and `Hash Based Collection`(for Youtube and Web URL).
- Implemented payload-based partitioning using a `tenant_id` field for data isolation within the new collections.
- Configured Qdrant collections for multi-tenancy, including settings like `payload_m=16` (per-tenant indexing), `m=0` (disabled global index), and a keyword payload index for `tenant_id` with `is_tenant=true`.

---

### Additional Information
#### Migration
The existing API interface of the `QdrantClient` class is maintained to avoid breaking changes in the application, ensuring a seamless transition. However, Open WebUI will unable to access all the old Qdrant collections. Go to: Admin Settings > Documents > Reindex Knowledge Base Vectors to migrating knowledge

#### Rollback

**Before running the migration in production:**

1. **Backup your database**: Create a snapshot of your Qdrant database 
2. **Test in a staging environment**: Try the migration in a non-production environment first

If you need to roll back, restore from your backup.

#### Benefits of Multi-Tenancy

- **Reduced RAM usage**: Significant decrease from ~14MB overhead per collection
- **Improved performance**: Better resource utilization
- **Optimized storage**: Data from the same tenant is co-located
- **Simplified management**: Fewer collections to manage


#### Sequence Diagram(s)

```mermaid
sequenceDiagram
    participant Client
    participant QdrantClient
    participant QdrantDB

    Client->>QdrantClient: insert(collection_name, items)
    QdrantClient->>QdrantClient: _get_collection_and_tenant_id(collection_name)
    QdrantClient->>QdrantClient: _create_multi_tenant_collection_if_not_exists(mt_collection_name)
    QdrantClient->>QdrantDB: Insert items with tenant_id in payload

    Client->>QdrantClient: search(collection_name, vectors, limit)
    QdrantClient->>QdrantClient: _get_collection_and_tenant_id(collection_name)
    QdrantClient->>QdrantDB: Search in mt_collection_name with tenant_id filter

    Client->>QdrantClient: delete(collection_name, ids/filter)
    QdrantClient->>QdrantClient: _get_collection_and_tenant_id(collection_name)
    QdrantClient->>QdrantDB: Delete points with tenant_id (and optional filters)
```

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.